### PR TITLE
Update README with info on using events

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,9 @@ These are the events that will be emitted by the directive.
 ```js
 'use strict'
 import Vue from 'vue'
-import VueYouTubeEmbed from 'vue-youtube-embed'
+import VueYouTubeEmbed, { events } from 'vue-youtube-embed'
+
 Vue.use(VueYouTubeEmbed)
-
-const {events} = VueYouTubeEmbed
-
 
 const app = new Vue({
   el: '#app',


### PR DESCRIPTION
Hi,

I believe that the README could use an update on importing events from the main module. The example file seems to be working fine, since the `VueYouTubeEmbed` still exposes all of the properties and methods to the global instance, but importing the library using Webpack fails.

Currently the docs say that in order to use the events constant one would have to:

```js
'use strict'

import Vue from 'vue'
import VueYouTubeEmbed from 'vue-youtube-embed'

Vue.use(VueYouTubeEmbed)

const {events} = VueYouTubeEmbed
```

However about three weeks ago a commit was introduced, that added an `export default` to the module. Therefore I believe in order to use events, one would have to do like this:

```js
'use strict'

import Vue from 'vue'
import VueYouTubeEmbed, { events } from 'vue-youtube-embed'

Vue.use(VueYouTubeEmbed)
```

Cheers!