### PR TITLE
Switched 'created' event for 'ready' event so that it runs after $el is inserted.

### DIFF
--- a/lib/vue-youtube-embed.js
+++ b/lib/vue-youtube-embed.js
@@ -197,7 +197,7 @@ var YouTubePlayer = exports.YouTubePlayer = {
       this.player[name](videoId);
     }
   },
-  created: function created() {
+  ready: function ready() {
     var _this3 = this;
 
     container.register(function (YouTube) {

--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ export const YouTubePlayer = {
       this.player[name](videoId)
     }
   },
-  created() {
+  ready() {
     container.register((YouTube) => {
       const {
         playerHeight : height = '390',

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -155,10 +155,10 @@ describe('YouTubePlayer', () => {
 
   })
 
-  describe('#created', () => {
+  describe('#ready', () => {
     it('should call container.register', () => {
       sinon.spy(container, 'register')
-      YouTubePlayer.created()
+      YouTubePlayer.ready()
 
       assert.ok(container.register.called)
       container.register.restore()
@@ -168,10 +168,10 @@ describe('YouTubePlayer', () => {
       it('should pass the default values', () => {
         const videoId = 'videoId'
         const component = {
-          created: YouTubePlayer.created,
+          ready: YouTubePlayer.ready,
           videoId
         }
-        component.created()
+        component.ready()
 
         const {options} = component.player
         assert.equal(options.videoId, 'videoId')
@@ -190,13 +190,13 @@ describe('YouTubePlayer', () => {
           autoplay: 1
         }
         const component = {
-          created: YouTubePlayer.created,
+          ready: YouTubePlayer.ready,
           videoId,
           playerWidth,
           playerHeight,
           playerVars
         }
-        component.created()
+        component.ready()
 
         const {options} = component.player
         assert.equal(options.videoId, videoId)
@@ -212,10 +212,10 @@ describe('YouTubePlayer', () => {
     context('default', () => {
       it('should call YT.Player.prototype.cueVideoById()', () => {
         const component = {
-          created: YouTubePlayer.created,
+          ready: YouTubePlayer.ready,
           update: YouTubePlayer.methods.update
         }
-        component.created()
+        component.ready()
         sinon.spy(component.player, 'cueVideoById')
         component.update('videoId')
         assert.ok(component.player.cueVideoById.called)
@@ -225,13 +225,13 @@ describe('YouTubePlayer', () => {
     context('autoplay is 0', () => {
       it('should call YT.Player.prototype.cueVideoById()', () => {
         const component = {
-          created: YouTubePlayer.created,
+          ready: YouTubePlayer.ready,
           update: YouTubePlayer.methods.update,
           playerVars: {
             autoplay: 0
           }
         }
-        component.created()
+        component.ready()
         sinon.spy(component.player, 'cueVideoById')
         component.update('videoId')
         assert.ok(component.player.cueVideoById.called)
@@ -241,13 +241,13 @@ describe('YouTubePlayer', () => {
     context('autoplay is 1', () => {
       it('should call YT.Player.prototype.loadVideoById()', () => {
         const component = {
-          created: YouTubePlayer.created,
+          ready: YouTubePlayer.ready,
           update: YouTubePlayer.methods.update,
           playerVars: {
             autoplay: 1
           }
         }
-        component.created()
+        component.ready()
         sinon.spy(component.player, 'loadVideoById')
         component.update('videoId')
         assert.ok(component.player.loadVideoById.called)


### PR DESCRIPTION
The video loaded fine on first load, but when we put it on a page in vue-router and navigated away/back it wouldn't load the video. I debugged it a little and found that the element with the incremented id didn't exist yet when it was trying to create the new player on that id. Switching created to ready solved the problem for us.