### PR TITLE
Fix for player not rendering on computed videoId

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,13 @@ export const YouTubePlayer = {
         playerVars = {autoplay: 0}
       } = this
       const name = `${playerVars.autoplay ? 'load' : 'cue'}VideoById`
-      this.player[name](videoId)
+      if (this.player.hasOwnProperty(name)) {
+        this.player[name](videoId)  
+      } else {
+        setTimeout(function () {
+          this.update(videoId)
+        }.bind(this), 100)
+      }
     }
   },
   mounted() {


### PR DESCRIPTION
When I have the videoId as a computed value, your watcher tries update the player. But I think the player is not ready yet because it throuws an JS error:
[Vue warn]: Error in watcher "videoId"
TypeError: this.player[name] is not a function

This small fix 'listens' for the property to exist on the player and then runs it