### PR TITLE
Fixed bug that caused it to crash on load

### DIFF
--- a/lib/vue-youtube-embed.js
+++ b/lib/vue-youtube-embed.js
@@ -178,7 +178,8 @@ var YouTubePlayer = exports.YouTubePlayer = {
   data: function data() {
     pid += 1;
     return {
-      elementId: 'youtube-player-' + pid
+      elementId: 'youtube-player-' + pid,
+      player: {}
     };
   },
 

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,8 @@ export const YouTubePlayer = {
   data() {
     pid += 1
     return {
-      elementId: `youtube-player-${pid}`
+      elementId: `youtube-player-${pid}`,
+      player: {}
     }
   },
   methods: {


### PR DESCRIPTION
If the player object isn't declared, it crashes in the update method.