### PR TITLE
Added check for youtube destroy method in beforeDestroy

### DIFF
--- a/lib/vue-youtube-embed.js
+++ b/lib/vue-youtube-embed.js
@@ -199,7 +199,7 @@ var YouTubePlayer = {
     });
   },
   beforeDestroy: function beforeDestroy () {
-    if (this.player !== null && this.player.destroy) {
+    if (this.player !== null) {
       this.player.destroy();
     }
     delete this.player;

--- a/lib/vue-youtube-embed.js
+++ b/lib/vue-youtube-embed.js
@@ -199,7 +199,7 @@ var YouTubePlayer = {
     });
   },
   beforeDestroy: function beforeDestroy () {
-    if (this.player !== null) {
+    if (this.player !== null && this.player.destroy) {
       this.player.destroy();
     }
     delete this.player;

--- a/src/player.js
+++ b/src/player.js
@@ -92,7 +92,7 @@ export default {
     })
   },
   beforeDestroy () {
-    if (this.player !== null) {
+    if (this.player !== null && this.player.destroy) {
       this.player.destroy()
     }
     delete this.player


### PR DESCRIPTION
We're using Vue-storybook (instead of Vue-Play) together with vue-youtube-embed. When I change a property of a component (in storybook) the beforeDestroy is executed, but for some reason the Youtube API destory method is not a function.

The error:
Error in beforeDestroy hook: "TypeError: this.player.destroy is not a function"

To prevent this I added a check if the method is there, before executing it. This solves the issue.