### PR TITLE
Make it work under SSR

### DIFF
--- a/lib/vue-youtube-embed.js
+++ b/lib/vue-youtube-embed.js
@@ -206,8 +206,8 @@ var YouTubePlayer = {
   }
 };
 
-var index = { YouTubePlayer: YouTubePlayer, getIdFromURL: getIdFromURL, getTimeFromURL: getTimeFromURL,
-  install: function (Vue, options) {
+var index = {
+  install: function install (Vue, options) {
     if ( options === void 0 ) options = { global: true };
 
     container.Vue = Vue;
@@ -241,6 +241,9 @@ var index = { YouTubePlayer: YouTubePlayer, getIdFromURL: getIdFromURL, getTimeF
   }
 };
 
+exports.YouTubePlayer = YouTubePlayer;
+exports.getIdFromURL = getIdFromURL;
+exports.getTimeFromURL = getTimeFromURL;
 exports['default'] = index;
 
 Object.defineProperty(exports, '__esModule', { value: true });

--- a/lib/vue-youtube-embed.js
+++ b/lib/vue-youtube-embed.js
@@ -206,41 +206,42 @@ var YouTubePlayer = {
   }
 };
 
-function install (Vue, options) {
-  if ( options === void 0 ) options = { global: true };
+var index = { YouTubePlayer: YouTubePlayer, getIdFromURL: getIdFromURL, getTimeFromURL: getTimeFromURL,
+  install: function (Vue, options) {
+    if ( options === void 0 ) options = { global: true };
 
-  container.Vue = Vue;
-  YouTubePlayer.ready = YouTubePlayer.mounted;
-  if (options.global) {
-    Vue.component('youtube', YouTubePlayer);
+    container.Vue = Vue;
+    YouTubePlayer.ready = YouTubePlayer.mounted;
+    if (options.global) {
+      Vue.component('youtube', YouTubePlayer);
+    }
+    Vue.prototype.$youtube = { getIdFromURL: getIdFromURL, getTimeFromURL: getTimeFromURL };
+
+    if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+      var tag = document.createElement('script');
+      tag.src = 'https://www.youtube.com/player_api';
+      var firstScriptTag = document.getElementsByTagName('script')[0];
+      firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+      window.onYouTubeIframeAPIReady = function () {
+        container.YT = YT;
+        var PlayerState = YT.PlayerState;
+
+        container.events[PlayerState.ENDED] = 'ended';
+        container.events[PlayerState.PLAYING] = 'playing';
+        container.events[PlayerState.PAUSED] = 'paused';
+        container.events[PlayerState.BUFFERING] = 'buffering';
+        container.events[PlayerState.CUED] = 'cued';
+
+        container.Vue.nextTick(function () {
+          container.run();
+        });
+      };
+    }
   }
-  Vue.prototype.$youtube = { getIdFromURL: getIdFromURL, getTimeFromURL: getTimeFromURL };
+};
 
-  var tag = document.createElement('script');
-  tag.src = 'https://www.youtube.com/player_api';
-  var firstScriptTag = document.getElementsByTagName('script')[0];
-  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
-
-  window.onYouTubeIframeAPIReady = function () {
-    container.YT = YT;
-    var PlayerState = YT.PlayerState;
-
-    container.events[PlayerState.ENDED] = 'ended';
-    container.events[PlayerState.PLAYING] = 'playing';
-    container.events[PlayerState.PAUSED] = 'paused';
-    container.events[PlayerState.BUFFERING] = 'buffering';
-    container.events[PlayerState.CUED] = 'cued';
-
-    Vue.nextTick(function () {
-      container.run();
-    });
-  };
-}
-
-exports.YouTubePlayer = YouTubePlayer;
-exports.getIdFromURL = getIdFromURL;
-exports.getTimeFromURL = getTimeFromURL;
-exports['default'] = install;
+exports['default'] = index;
 
 Object.defineProperty(exports, '__esModule', { value: true });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-youtube-embed",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Vue.js and YouTube",
   "main": "lib/vue-youtube-embed.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -2,33 +2,35 @@ import { getIdFromURL, getTimeFromURL } from './utils'
 import container from './container'
 import YouTubePlayer from './player'
 
-export { YouTubePlayer, getIdFromURL, getTimeFromURL }
+export default { YouTubePlayer, getIdFromURL, getTimeFromURL,
+  install: function (Vue, options = { global: true }) {
+    container.Vue = Vue
+    YouTubePlayer.ready = YouTubePlayer.mounted
+    if (options.global) {
+      Vue.component('youtube', YouTubePlayer)
+    }
+    Vue.prototype.$youtube = { getIdFromURL, getTimeFromURL }
 
-export default function install (Vue, options = { global: true }) {
-  container.Vue = Vue
-  YouTubePlayer.ready = YouTubePlayer.mounted
-  if (options.global) {
-    Vue.component('youtube', YouTubePlayer)
-  }
-  Vue.prototype.$youtube = { getIdFromURL, getTimeFromURL }
+    if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+      const tag = document.createElement('script')
+      tag.src = 'https://www.youtube.com/player_api'
+      const firstScriptTag = document.getElementsByTagName('script')[0]
+      firstScriptTag.parentNode.insertBefore(tag, firstScriptTag)
 
-  const tag = document.createElement('script')
-  tag.src = 'https://www.youtube.com/player_api'
-  const firstScriptTag = document.getElementsByTagName('script')[0]
-  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag)
+      window.onYouTubeIframeAPIReady = function () {
+        container.YT = YT
+        const { PlayerState } = YT
 
-  window.onYouTubeIframeAPIReady = function () {
-    container.YT = YT
-    const { PlayerState } = YT
+        container.events[PlayerState.ENDED] = 'ended'
+        container.events[PlayerState.PLAYING] = 'playing'
+        container.events[PlayerState.PAUSED] = 'paused'
+        container.events[PlayerState.BUFFERING] = 'buffering'
+        container.events[PlayerState.CUED] = 'cued'
 
-    container.events[PlayerState.ENDED] = 'ended'
-    container.events[PlayerState.PLAYING] = 'playing'
-    container.events[PlayerState.PAUSED] = 'paused'
-    container.events[PlayerState.BUFFERING] = 'buffering'
-    container.events[PlayerState.CUED] = 'cued'
-
-    Vue.nextTick(() => {
-      container.run()
-    })
+        container.Vue.nextTick(() => {
+          container.run()
+        })
+      }
+    }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,10 @@ import { getIdFromURL, getTimeFromURL } from './utils'
 import container from './container'
 import YouTubePlayer from './player'
 
-export default { YouTubePlayer, getIdFromURL, getTimeFromURL,
-  install: function (Vue, options = { global: true }) {
+export { YouTubePlayer, getIdFromURL, getTimeFromURL }
+
+export default {
+  install (Vue, options = { global: true }) {
     container.Vue = Vue
     YouTubePlayer.ready = YouTubePlayer.mounted
     if (options.global) {
@@ -34,3 +36,4 @@ export default { YouTubePlayer, getIdFromURL, getTimeFromURL,
     }
   }
 }
+


### PR DESCRIPTION
Howdy;
I used some simple detection for global `window` & `document` objects to short-circuit attempts to make the video play when using server-side rendering under Vue.js 2.x

This is working for us currently, and tests are still passing.  Let me know if you would like further changes or do not like this approach.

Also - I didn't bump the `package.json`, so that might have to happen if you accept the PR and want to bump the version and publish to NPM.

Thanks!