### PR TITLE
Changed event.player to event.target in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ const app = new Vue({
   },
   methods: {
     ready (event) {
-      this.player = event.player
+      this.player = event.target
     },
     playing (event) {
       // The player is playing a video.


### PR DESCRIPTION
Hey

I just tried this out and it appears that the player is now on event.target instead of event.player, as documented until now. 

Thanks for this great plugin!