### PR TITLE
Remove showInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ These are available props.
 
 * `player-width`: `String` or `Number`, default value is `640`
 * `player-height`: `String` or `Number`, default value is `390`
-* `player-vars`: `Object`, default value is `{start: 0, autoplay: 0}` Can also specify `rel` and `showInfo`
+* `player-vars`: `Object`, default value is `{start: 0, autoplay: 0}` Can also specify `rel`.
 * `video-id`: `String`, `required`
 * `mute`: `Boolean` default value is `false`
 

--- a/play/PlayerVars.vue
+++ b/play/PlayerVars.vue
@@ -25,9 +25,6 @@ export default {
         start: 60
       },
       player3: {
-        showinfo: 0
-      },
-      player4: {
         playlist: 'M7lc1UVf-VE,M7lc1UVf-VE,M7lc1UVf-VE'
       }
     }


### PR DESCRIPTION
👋 

This PR removes showInfo parameter from readme and demo. It has been deprecated as of 25 Sep 2018.

Resources:
https://developers.google.com/youtube/player_parameters#release_notes_08_23_2018
https://developers.google.com/youtube/player_parameters#showinfo

Thanks!