### PR TITLE
Update player height to match 16:9 ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Please pass the ID of the video that you'd like to show.
 These are available props.
 
 * `player-width`: `String` or `Number`, default value is `640`
-* `player-height`: `String` or `Number`, default value is `390`
+* `player-height`: `String` or `Number`, default value is `360`
 * `player-vars`: `Object`, default value is `{start: 0, autoplay: 0}` Can also specify `rel`.
 * `video-id`: `String`, `required`
 * `mute`: `Boolean` default value is `false`

--- a/example/app.js
+++ b/example/app.js
@@ -9,7 +9,7 @@ window.app = new Vue({
     nextId: '',
     videos: [],
     width: '640',
-    height: '390'
+    height: '360'
   },
   methods: {
     pause: function () {

--- a/lib/vue-youtube-embed.js
+++ b/lib/vue-youtube-embed.js
@@ -101,7 +101,7 @@ var YouTubePlayer = {
   props: {
     playerHeight: {
       type: [String, Number],
-      default: '390'
+      default: '360'
     },
     playerWidth: {
       type: [String, Number],

--- a/lib/vue-youtube-embed.umd.js
+++ b/lib/vue-youtube-embed.umd.js
@@ -107,7 +107,7 @@
     props: {
       playerHeight: {
         type: [String, Number],
-        default: '390'
+        default: '360'
       },
       playerWidth: {
         type: [String, Number],

--- a/play/Size.vue
+++ b/play/Size.vue
@@ -21,7 +21,7 @@ export default {
   data () {
     return {
       title: 'Height and Width',
-      height: 390,
+      height: 360,
       width: 640
     }
   },

--- a/src/player.js
+++ b/src/player.js
@@ -6,7 +6,7 @@ export default {
   props: {
     playerHeight: {
       type: [String, Number],
-      default: '390'
+      default: '360'
     },
     playerWidth: {
       type: [String, Number],

--- a/test/player.spec.js
+++ b/test/player.spec.js
@@ -53,7 +53,7 @@ describe('YouTubePlayer', () => {
 
         assert.equal(vm.videoId, 'videoId')
         assert.equal(vm.playerWidth, '640')
-        assert.equal(vm.playerHeight, '390')
+        assert.equal(vm.playerHeight, '360')
       })
     })
 


### PR DESCRIPTION
The aspect ratio 16:9 produces a 360px height with a 640px width. I think the old 390 value might have come from when YouTube had the player bar, but now the controls are overlayed on the videos. I understand you can change the values via props, but I think it'd be a great convenience to the users to not have to set it themselves for the most common video aspect ratio.