### PR TITLE
Give the component the name 'YoutubeEmbed'

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -3,6 +3,7 @@ import container from './container'
 let pid = 0
 
 export default {
+  name: 'YoutubeEmbed',
   props: {
     playerHeight: {
       type: [String, Number],


### PR DESCRIPTION
This allows it to be selected during unit tests, otherwise something
like `wrapper.findAll({ name: 'YoutubeEmbed' })` (or any other name
for that matter) will never yield anything.
Fixes #58