### PR TITLE
Feature: Defer youtube player lib loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Vue.use(VueYouTubeEmbed)
 Vue.use(VueYouTubeEmbed, { global: false })
 // if you want to install the component globally with a different name
 Vue.use(VueYouTubeEmbed, { global: true, componentId: "youtube-media" })
+// if you want to start the youtube player library at a later point
+Vue.use(VueYouTubeEmbed, { defer: Promise.resolve() })
 ```
 
 ## Usage

--- a/lib/vue-youtube-embed.js
+++ b/lib/vue-youtube-embed.js
@@ -215,6 +215,7 @@ var index = {
     YouTubePlayer.ready = YouTubePlayer.mounted;
     var global = options.global; if ( global === void 0 ) global = true;
     var componentId = options.componentId; if ( componentId === void 0 ) componentId = 'youtube';
+    var defer = options.defer; if ( defer === void 0 ) defer = Promise.resolve();
 
     if (global) {
       // if there is a global component with "youtube" identifier already taken
@@ -224,25 +225,27 @@ var index = {
     Vue.prototype.$youtube = { getIdFromURL: getIdFromURL, getTimeFromURL: getTimeFromURL };
 
     if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-      var tag = document.createElement('script');
-      tag.src = 'https://www.youtube.com/player_api';
-      var firstScriptTag = document.getElementsByTagName('script')[0];
-      firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+      defer.then(function () {
+        var tag = document.createElement('script');
+        tag.src = 'https://www.youtube.com/player_api';
+        var firstScriptTag = document.getElementsByTagName('script')[0];
+        firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 
-      window.onYouTubeIframeAPIReady = function () {
-        container.YT = YT;
-        var PlayerState = YT.PlayerState;
+        window.onYouTubeIframeAPIReady = function () {
+          container.YT = YT;
+          var PlayerState = YT.PlayerState;
 
-        container.events[PlayerState.ENDED] = 'ended';
-        container.events[PlayerState.PLAYING] = 'playing';
-        container.events[PlayerState.PAUSED] = 'paused';
-        container.events[PlayerState.BUFFERING] = 'buffering';
-        container.events[PlayerState.CUED] = 'cued';
+          container.events[PlayerState.ENDED] = 'ended';
+          container.events[PlayerState.PLAYING] = 'playing';
+          container.events[PlayerState.PAUSED] = 'paused';
+          container.events[PlayerState.BUFFERING] = 'buffering';
+          container.events[PlayerState.CUED] = 'cued';
 
-        container.Vue.nextTick(function () {
-          container.run();
-        });
-      };
+          container.Vue.nextTick(function () {
+            container.run();
+          });
+        };
+      });
     }
   }
 };

--- a/lib/vue-youtube-embed.umd.js
+++ b/lib/vue-youtube-embed.umd.js
@@ -221,6 +221,7 @@
       YouTubePlayer.ready = YouTubePlayer.mounted;
       var global = options.global; if ( global === void 0 ) global = true;
       var componentId = options.componentId; if ( componentId === void 0 ) componentId = 'youtube';
+      var defer = options.defer; if ( defer === void 0 ) defer = Promise.resolve();
 
       if (global) {
         // if there is a global component with "youtube" identifier already taken
@@ -230,25 +231,27 @@
       Vue.prototype.$youtube = { getIdFromURL: getIdFromURL, getTimeFromURL: getTimeFromURL };
 
       if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-        var tag = document.createElement('script');
-        tag.src = 'https://www.youtube.com/player_api';
-        var firstScriptTag = document.getElementsByTagName('script')[0];
-        firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+        defer.then(function () {
+          var tag = document.createElement('script');
+          tag.src = 'https://www.youtube.com/player_api';
+          var firstScriptTag = document.getElementsByTagName('script')[0];
+          firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 
-        window.onYouTubeIframeAPIReady = function () {
-          container.YT = YT;
-          var PlayerState = YT.PlayerState;
+          window.onYouTubeIframeAPIReady = function () {
+            container.YT = YT;
+            var PlayerState = YT.PlayerState;
 
-          container.events[PlayerState.ENDED] = 'ended';
-          container.events[PlayerState.PLAYING] = 'playing';
-          container.events[PlayerState.PAUSED] = 'paused';
-          container.events[PlayerState.BUFFERING] = 'buffering';
-          container.events[PlayerState.CUED] = 'cued';
+            container.events[PlayerState.ENDED] = 'ended';
+            container.events[PlayerState.PLAYING] = 'playing';
+            container.events[PlayerState.PAUSED] = 'paused';
+            container.events[PlayerState.BUFFERING] = 'buffering';
+            container.events[PlayerState.CUED] = 'cued';
 
-          container.Vue.nextTick(function () {
-            container.run();
-          });
-        };
+            container.Vue.nextTick(function () {
+              container.run();
+            });
+          };
+        });
       }
     }
   };

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ export default {
   install (Vue, options = {}) {
     container.Vue = Vue
     YouTubePlayer.ready = YouTubePlayer.mounted
-    const { global = true, componentId = 'youtube' } = options
+    const { global = true, componentId = 'youtube', defer = Promise.resolve() } = options
 
     if (global) {
       // if there is a global component with "youtube" identifier already taken
@@ -18,25 +18,27 @@ export default {
     Vue.prototype.$youtube = { getIdFromURL, getTimeFromURL }
 
     if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-      const tag = document.createElement('script')
-      tag.src = 'https://www.youtube.com/player_api'
-      const firstScriptTag = document.getElementsByTagName('script')[0]
-      firstScriptTag.parentNode.insertBefore(tag, firstScriptTag)
+      defer.then(() => {
+        const tag = document.createElement('script')
+        tag.src = 'https://www.youtube.com/player_api'
+        const firstScriptTag = document.getElementsByTagName('script')[0]
+        firstScriptTag.parentNode.insertBefore(tag, firstScriptTag)
 
-      window.onYouTubeIframeAPIReady = function () {
-        container.YT = YT
-        const { PlayerState } = YT
+        window.onYouTubeIframeAPIReady = function () {
+          container.YT = YT
+          const { PlayerState } = YT
 
-        container.events[PlayerState.ENDED] = 'ended'
-        container.events[PlayerState.PLAYING] = 'playing'
-        container.events[PlayerState.PAUSED] = 'paused'
-        container.events[PlayerState.BUFFERING] = 'buffering'
-        container.events[PlayerState.CUED] = 'cued'
+          container.events[PlayerState.ENDED] = 'ended'
+          container.events[PlayerState.PLAYING] = 'playing'
+          container.events[PlayerState.PAUSED] = 'paused'
+          container.events[PlayerState.BUFFERING] = 'buffering'
+          container.events[PlayerState.CUED] = 'cued'
 
-        container.Vue.nextTick(() => {
-          container.run()
-        })
-      }
+          container.Vue.nextTick(() => {
+            container.run()
+          })
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
Hey there, great library!
The goal of this PR is to give the developer, if they want, the control of when the player api lib will be loaded.

e.g. currently whats being loaded right away:
- player_api (1kb)
- www-widgetapi.js (9kb)
- per loaded video, not playing
    - embed html (17kb)
    - js/bg (5.3kb)
    - player css (40.4kb)
    - embed-player.js (39kb)
    - **base.js (1.2mb)**
- doubleclick ad trackings:
    - id (0.2kb)
    - ad_status.js (0.01kb)

Bandwith and parse time is relevant here.

Tell me what you think, cheers!